### PR TITLE
remove deepMerge on new data. Don't break EJSON objects.

### DIFF
--- a/lib/ssr_context.js
+++ b/lib/ssr_context.js
@@ -1,8 +1,6 @@
 // server/ssr_context.js
 // stolen from https://github.com/kadirahq/flow-router/blob/ssr/server/ssr_context.js
 
-import deepMerge from 'deepmerge';
-
 export default class SsrContext {
   constructor() {
     this._collections = {};
@@ -26,8 +24,8 @@ export default class SsrContext {
       );
     }
 
-    const args = [name].concat(params);
-    const data = fastRenderContext.subscribe(...args);
+
+    const data = fastRenderContext.subscribe(name, ...params);
     this.addData(data);
   }
 
@@ -38,9 +36,9 @@ export default class SsrContext {
         collData.forEach((item) => {
           const existingDoc = collection.findOne(item._id);
           if (existingDoc) {
-            const newDoc = deepMerge(existingDoc, item);
+            const newDoc = { ...existingDoc, ...item };
             delete newDoc._id;
-            collection.update(item._id, newDoc);
+            collection.update(item._id, { $set: newDoc });
           } else {
             collection.insert(item);
           }

--- a/package.js
+++ b/package.js
@@ -9,7 +9,6 @@ Package.describe({
 Npm.depends({
   'cookie-parser': '1.4.1',
   'cheerio': '0.20.0',
-  'deepmerge': '0.2.10'
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
When making deepMerge it merges dates and other deep objects as plain objects, so if we create some date objects like createdAt on docs fields it will be converted to empty objects.
Also default publish/subscribe behaviour is to shallow merge objects. So we have to do.
