### PR TITLE
Support for routes generator function for support multi-hosts logic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ What about your SEO? Just `npm install react-helmet` and hook it with `htmlHook(
 The `routes` argument takes the routes you want react-router to use (you don't have to call `ReactDOM.render()` yourself)<br />
 Read the [react-router documentation](https://github.com/rackt/react-router/tree/master/docs) for more informations.
 
-#### routes
+#### routes element|function(hostname):element
 Your main `<Route />` node of your application.<br />
 **Notice that there is no `<Router />` element, ReactRouterSSR takes care of creating it on the client and server with the correct parameters**
 

--- a/lib/client.jsx
+++ b/lib/client.jsx
@@ -48,7 +48,10 @@ const ReactRouterSSR = {
         });
       }
 
-      var routes = getRoutes(window.location.hostname);
+
+      var routes = getRoutes({
+        host: window.location.host,
+      });
 
       let appGenerator = (addProps) => (
         <Router

--- a/lib/client.jsx
+++ b/lib/client.jsx
@@ -3,7 +3,9 @@ import ReactDOM from 'react-dom';
 import { Router, browserHistory } from 'react-router';
 
 const ReactRouterSSR = {
-  Run(routes, clientOptions) {
+  Run(_getRoutes, clientOptions) {
+    var getRoutes = typeof (getRoutes) != 'function' ? (() => _getRoutes) : _getRoutes;
+
     if (!clientOptions) {
       clientOptions = {};
     }
@@ -45,6 +47,8 @@ const ReactRouterSSR = {
           clientOptions.rehydrateHook(rehydratedData);
         });
       }
+
+      var routes = getRoutes(window.location.hostname);
 
       let appGenerator = (addProps) => (
         <Router

--- a/lib/client.jsx
+++ b/lib/client.jsx
@@ -4,7 +4,7 @@ import { Router, browserHistory } from 'react-router';
 
 const ReactRouterSSR = {
   Run(_getRoutes, clientOptions) {
-    var getRoutes = typeof (getRoutes) != 'function' ? (() => _getRoutes) : _getRoutes;
+    var getRoutes = typeof (_getRoutes) != 'function' ? (() => _getRoutes) : _getRoutes;
 
     if (!clientOptions) {
       clientOptions = {};

--- a/lib/server.jsx
+++ b/lib/server.jsx
@@ -47,7 +47,7 @@ ReactRouterSSR.LoadWebpackStats = function(stats) {
 patchSubscribeData(ReactRouterSSR);
 
 ReactRouterSSR.Run = function(_getRoutes, clientOptions, serverOptions) {
-  var getRoutes = typeof (getRoutes) != 'function' ? (() => _getRoutes) : _getRoutes;
+  var getRoutes = typeof (_getRoutes) != 'function' ? (() => _getRoutes) : _getRoutes;
   
   if (!clientOptions) {
     clientOptions = {};

--- a/lib/server.jsx
+++ b/lib/server.jsx
@@ -83,8 +83,10 @@ ReactRouterSSR.Run = function(_getRoutes, clientOptions, serverOptions) {
         if (typeof serverOptions.historyHook === 'function') {
           history = serverOptions.historyHook(history);
         }
-
-        var routes = getRoutes(req.headers.host);
+        
+        var routes = getRoutes({
+          host: req.headers.host,
+        });
 
         ReactRouterMatch({ history, routes, location: req.url }, Meteor.bindEnvironment((err, redirectLocation, renderProps) => {
           if (err) {

--- a/lib/server.jsx
+++ b/lib/server.jsx
@@ -46,7 +46,8 @@ ReactRouterSSR.LoadWebpackStats = function(stats) {
 // this line just patches Subscribe and find mechanisms
 patchSubscribeData(ReactRouterSSR);
 
-ReactRouterSSR.Run = function(routes, clientOptions, serverOptions) {
+ReactRouterSSR.Run = function(_getRoutes, clientOptions, serverOptions) {
+  var getRoutes = typeof (getRoutes) != 'function' ? (() => _getRoutes) : _getRoutes;
   
   if (!clientOptions) {
     clientOptions = {};
@@ -82,6 +83,8 @@ ReactRouterSSR.Run = function(routes, clientOptions, serverOptions) {
         if (typeof serverOptions.historyHook === 'function') {
           history = serverOptions.historyHook(history);
         }
+
+        var routes = getRoutes(req.headers.host);
 
         ReactRouterMatch({ history, routes, location: req.url }, Meteor.bindEnvironment((err, redirectLocation, renderProps) => {
           if (err) {


### PR DESCRIPTION
We needed a multi-hosts apps.
Perhaps it will be applied here, in this repo?
Is there something to fix?
Are there adjustments?

Example
```jsx
ReactRouterSSR.Run((hostname) => {
  return <div>
    {Meteor.routes.find({ hostname }).fetch().map(() => {
      return <Route key={document._id} path={document.path} component={() => {
        return <div>{document.path}</div>;
      }}/>;
    })}
  </div>;
});
```